### PR TITLE
Potentially fixed scale exception.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -130,17 +130,17 @@ class AutoCropFaces:
             return (out, selected_crop_data)
 
         # Determine the index of the face with the maximum width
-        max_width_index = max(range(len(selected_faces)), key=lambda i: selected_faces[i].shape[2])
+        max_width_index = max(range(len(selected_faces)), key=lambda i: selected_faces[i].shape[1])
 
         # Determine the maximum width
-        max_width = selected_faces[max_width_index].shape[2]
-        max_height = selected_faces[max_width_index].shape[1]
+        max_width = selected_faces[max_width_index].shape[1]
+        max_height = selected_faces[max_width_index].shape[2]
         shape = (max_height, max_width)
 
         out = None
         # All images need to have the same width/height to fit into the tensor such that we can output as image batches.
         for face_image in selected_faces:
-            if shape != image.shape[1:3]: # Check all images against the largest image and scale it to that size.
+            if shape != face_image.shape[1:3]: # Determine whether cropped face image size matches largest cropped face image. 
                 face_image = comfy.utils.common_upscale( # This method expects (batch, channel, height, width)
                     face_image.movedim(-1, 1), # Move channel dimension to width dimension
                     max_height, # Height


### PR DESCRIPTION
Thanks for the additional improvements, though after testing seems like I"m encountering some exceptions:
```
Error occurred when executing AutoCropFaces:

Sizes of tensors must match except in dimension 0. Expected size 512 but got size 511 for tensor number 1 in the list.

File "/home/sea/ComfyUI/execution.py", line 151, in recursive_execute
output_data, output_ui = get_output_data(obj, input_data_all)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/sea/ComfyUI/execution.py", line 81, in get_output_data
return_values = map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/sea/ComfyUI/execution.py", line 74, in map_node_over_list
results.append(getattr(obj, func)(**slice_dict(input_data_all, i)))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/sea/ComfyUI/custom_nodes/ComfyUI-AutoCropFaces/__init__.py", line 155, in auto_crop_faces
out = torch.cat((out, face_image), dim=0)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
This is because widths and heights were swapped here which I fixed:
```
        # Determine the index of the face with the maximum width
        max_width_index = max(range(len(selected_faces)), key=lambda i: selected_faces[i].shape[2])

        # Determine the maximum width
        max_width = selected_faces[max_width_index].shape[2]
        max_height = selected_faces[max_width_index].shape[1]
        shape = (max_height, max_width)
```
It's only for `comfy.utils.common_upscale` that has it's widths/heights swapped.

Also, regarding this line:
```
            if shape != image.shape[1:3]: # Check all images against the largest image and scale it to that size.
```
Shouldn't this be this or am I misunderstanding:
```
            if shape != face_image.shape[1:3]: # Determine whether cropped face image size matches largest cropped face image. 
```